### PR TITLE
fix: Update stow ignore list and improve refresh script

### DIFF
--- a/.stowrc
+++ b/.stowrc
@@ -1,4 +1,7 @@
 --target=~/.config
 --ignore=.stowrc
 --ignore=setup.sh
+--ignore=refresh.sh
 --ignore=DS_Store
+--ignore=README.md
+--ignore=.github

--- a/refresh.sh
+++ b/refresh.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
-stow --delete . && ./setup.sh
+# Remove existing symlinks
+stow --delete .
+
+# Stow will fail if real files exist in target - that's expected
+# Run with -v to see what's happening
+stow . -v


### PR DESCRIPTION
## Summary
- Add `refresh.sh`, `README.md`, and `.github` to stow ignore list to prevent them from being symlinked to `~/.config`
- Simplify `refresh.sh` to safely re-stow without `--adopt` flag, which could overwrite dotfiles repo with target files

## Test plan
- [ ] Run `./refresh.sh` and verify symlinks are created correctly
- [ ] Verify `refresh.sh`, `README.md`, and `.github` are not symlinked to `~/.config`